### PR TITLE
Fix Jekyll Icon Path

### DIFF
--- a/lib/shipyard-framework/icons.rb
+++ b/lib/shipyard-framework/icons.rb
@@ -20,7 +20,7 @@ module Shipyard
     end
 
     def base_path
-      "#{@base_path}/icons.svg"
+      "#{@base_path}/assets/icons.svg"
     end
 
     def asset_path(svg_id)

--- a/lib/shipyard-framework/icons.rb
+++ b/lib/shipyard-framework/icons.rb
@@ -7,9 +7,10 @@ module Shipyard
     delegate :each, :find, to: :icons
     delegate :execute_if_updated, :execute, :updated?, to: :updater
 
-    def initialize(icon_directory, output_directory)
+    def initialize(icon_directory, output_directory, base_path = '/assets')
       @path = icon_directory
       @public = output_directory
+      @base_path = base_path
       reload
     end
 
@@ -19,7 +20,7 @@ module Shipyard
     end
 
     def base_path
-      '/assets/icons.svg'
+      "#{@base_path}/icons.svg"
     end
 
     def asset_path(svg_id)

--- a/lib/shipyard-framework/jekyll/hooks.rb
+++ b/lib/shipyard-framework/jekyll/hooks.rb
@@ -1,5 +1,9 @@
 Jekyll::Hooks.register :site, :pre_render do |post|
-  $icons = Shipyard::Icons.new '_assets/icons/', '_site/assets/'
+  $icons = Shipyard::Icons.new(
+    '_assets/icons/',
+    '_site/assets/',
+    post.config['baseurl']
+  )
 end
 
 Jekyll::Hooks.register :site, :post_write do |post|


### PR DESCRIPTION
This PR fixes the jekyll icon path for the "production" styleguide since it currently lives at `/shipyard/` as the base url.