### PR TITLE
Stop Travis Emails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ branches:
     - gh-pages
     - /skip-ci(.*)/
 notifications:
+  email: false
   slack:
     on_success: always
     rooms:


### PR DESCRIPTION
This PR stops the Travis CI emails on every commit.