### PR TITLE
Improve Box Documentation

### DIFF
--- a/assets/stylesheets/shipyard/components/_boxes.sass
+++ b/assets/stylesheets/shipyard/components/_boxes.sass
@@ -13,32 +13,22 @@
   &-secondary
     background: $gray-lighter
 
-  &-rounded
-    border-radius: 1000px
-
   &-link
     color: $blue
     cursor: pointer
-    &:hover, &:active, &-selected, &-active
+    &:hover, &:active, &-active
       color: $blue-dark
       outline: none
       box-shadow: 0 0 4px 1px rgba($blue,.5)
-    &-active-green,
-    &-active-green:hover,
-    &-active-green:active
+    &-selected,
+    &-selected:hover,
+    &-selected:active
       outline: none
       cursor: default
       box-shadow: 0 0 4px 1px rgba(darken($green, 5%),.75)
 
   &-padding
     +respond-to(padding, $margins)
-
-  // Box: Margins
-  &-margin
-    +all-media-sizes
-      @each $size, $margin in (sm: 10px 0, md: 15px 0, lg: 30px 0)
-        &-#{$size}
-          margin: $margin
 
   // Box Sizes
   +all-media-sizes

--- a/assets/stylesheets/shipyard/mixins/_prefixed.sass
+++ b/assets/stylesheets/shipyard/mixins/_prefixed.sass
@@ -14,6 +14,8 @@
   -webkit-backdrop-filter: $value
 
 @mixin placeholder
+  &::placeholder
+    @content
   &:-moz-placeholder
     @content
   &:-ms-input-placeholder

--- a/lib/shipyard-framework/jekyll/tags/box_tag.rb
+++ b/lib/shipyard-framework/jekyll/tags/box_tag.rb
@@ -9,7 +9,7 @@ module Shipyard
         super
         @types = []
         types.tr(' ','').split(',').each do |type|
-          @types << type.tr(':','').to_sym
+          @types << type.tr(':','').tr('_','-').to_sym
         end
       end
 

--- a/lib/shipyard-framework/version.rb
+++ b/lib/shipyard-framework/version.rb
@@ -1,3 +1,3 @@
 module Shipyard
-  VERSION = '0.5.54'
+  VERSION = '0.5.55'
 end

--- a/styleguide/components/boxes.md
+++ b/styleguide/components/boxes.md
@@ -1,7 +1,7 @@
 ---
 title: Shipyard Boxes
 description: Boxes should be used to grab a draw attention to specific groups of content, and are most useful to linked content. By default, all boxes need to have the base class of `.box` in order to function properly.
-box_sizes: [xxs, xs, sm, md, lg, xl]
+box_sizes: [xxs, xs, sm, md, lg, xl, xxl]
 ---
 
 {% include page-heading.html page=page %}
@@ -29,7 +29,25 @@ box_sizes: [xxs, xs, sm, md, lg, xl]
 ### Linked `.box-link`
 <p class="text-light margin-bottom-sm">Useful when linking important components to another page or another group of content.</p>
 
-{% box :link, :padding %}
+{% box :link %}
+  <p>Donec id elit non mi porta gravida at eget metus. Aenean lacinia bibendum nulla sed consectetur. Etiam porta sem malesuada magna mollis euismod. Cras mattis consectetur purus sit amet fermentum. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Integer posuere erat a ante venenatis dapibus posuere velit aliquet.</p>
+{% endbox %}
+
+---
+
+### Linked & Active `.box-link-active`
+<p class="text-light margin-bottom-sm">Useful when linking important components to another page or another group of content.</p>
+
+{% box :link, :link_active %}
+  <p>Donec id elit non mi porta gravida at eget metus. Aenean lacinia bibendum nulla sed consectetur. Etiam porta sem malesuada magna mollis euismod. Cras mattis consectetur purus sit amet fermentum. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Integer posuere erat a ante venenatis dapibus posuere velit aliquet.</p>
+{% endbox %}
+
+---
+
+### Linked & Selected `.box-link-selected`
+<p class="text-light margin-bottom-sm">Useful when highlighting a linked box that's been selected by the user.</p>
+
+{% box :link, :link_selected %}
   <p>Donec id elit non mi porta gravida at eget metus. Aenean lacinia bibendum nulla sed consectetur. Etiam porta sem malesuada magna mollis euismod. Cras mattis consectetur purus sit amet fermentum. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Integer posuere erat a ante venenatis dapibus posuere velit aliquet.</p>
 {% endbox %}
 
@@ -38,9 +56,10 @@ box_sizes: [xxs, xs, sm, md, lg, xl]
 ### Secondary `.box-secondary`
 <p class="text-light margin-bottom-sm">Useful when connecting secondary information to the default box styles.</p>
 
-{% box :secondary, :padding %}
+{% box :secondary %}
   <p>Donec id elit non mi porta gravida at eget metus. Aenean lacinia bibendum nulla sed consectetur. Etiam porta sem malesuada magna mollis euismod. Cras mattis consectetur purus sit amet fermentum. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Integer posuere erat a ante venenatis dapibus posuere velit aliquet.</p>
 {% endbox %}
+
 
 ---
 


### PR DESCRIPTION
This PR introduces some small breaking changes along with the improved documentation for the box components.
- killed `.box-rounded`
- killed `.box-margin` for the other margin utility classes.
- changed `.box-link-active-green` to `.box-selected`