### PR TITLE
Add Rounded Boxes

### DIFF
--- a/assets/stylesheets/shipyard/components/_boxes.sass
+++ b/assets/stylesheets/shipyard/components/_boxes.sass
@@ -30,6 +30,9 @@
   &-padding
     +respond-to(padding, $margins)
 
+  &-rounded
+    border-radius: 1000px
+
   // Box Sizes
   +all-media-sizes
     @each $size, $height in (xxs: 50px, xs: 60px, sm: 70px, md: 80px, lg: 90px, xl: 100px, xxl: 110px)

--- a/lib/shipyard-framework/version.rb
+++ b/lib/shipyard-framework/version.rb
@@ -1,3 +1,3 @@
 module Shipyard
-  VERSION = '0.5.58'
+  VERSION = '0.5.59'
 end

--- a/styleguide/Gemfile.lock
+++ b/styleguide/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    shipyard-framework (0.5.57)
+    shipyard-framework (0.5.59)
       actionview (~> 5.0)
       sprockets-es6 (~> 0.9.2)
 
@@ -36,7 +36,7 @@ GEM
     fastimage (2.1.0)
     ffi (1.9.18)
     forwardable-extended (2.6.0)
-    i18n (0.9.0)
+    i18n (0.9.1)
       concurrent-ruby (~> 1.0)
     jekyll (3.6.2)
       addressable (~> 2.4)
@@ -88,7 +88,7 @@ GEM
       ffi (>= 0.5.0, < 2)
     rouge (2.2.1)
     safe_yaml (1.0.4)
-    sass (3.5.2)
+    sass (3.5.3)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)

--- a/styleguide/components/boxes.md
+++ b/styleguide/components/boxes.md
@@ -71,3 +71,14 @@ box_sizes: [xxs, xs, sm, md, lg, xl, xxl]
     <strong class="center text-lighter text-sm">.box-{{ size }}</strong>
   </div>
 {% endfor %}
+
+---
+
+### Rounded `.box-rounded`
+<p class="text-light margin-bottom-sm">Useful when you need a box with rounded corners.</p>
+
+{% for size in page.box_sizes %}
+  <div class="box box-rounded box-{{ size }} margin-top-md">
+    <strong class="center text-lighter text-sm">.box-{{ size }}</strong>
+  </div>
+{% endfor %}


### PR DESCRIPTION
This PR adds the rounded boxes back in via the `.box-rounded` class, which is apparently being used.