### PR TITLE
Fix Icon Method Overlap

### DIFF
--- a/lib/shipyard-framework/helpers/icon_helper.rb
+++ b/lib/shipyard-framework/helpers/icon_helper.rb
@@ -4,6 +4,16 @@ module Shipyard
     include ActionView::Helpers::TagHelper
 
     def icon(name, options={})
+      process_icon(name, options)
+    end
+
+    def get_icon(name, options={})
+      process_icon(name, options)
+    end
+
+    private
+
+    def process_icon(name, options={})
       if name.is_a? Symbol
         svg = find_icon(symbol: name)
         svg_use_tag svg, options
@@ -12,8 +22,6 @@ module Shipyard
         svg_tag svg, options
       end
     end
-
-    private
 
     def find_icon(hash)
       icon = $icons.icons.detect { |i| i[hash.keys.first] == hash.values.first }

--- a/lib/shipyard-framework/version.rb
+++ b/lib/shipyard-framework/version.rb
@@ -1,3 +1,3 @@
 module Shipyard
-  VERSION = '0.5.62'
+  VERSION = '0.5.63'
 end

--- a/styleguide/Gemfile.lock
+++ b/styleguide/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    shipyard-framework (0.5.62)
+    shipyard-framework (0.5.63)
       actionview (~> 5.0)
       sprockets-es6 (~> 0.9.2)
 


### PR DESCRIPTION
This PR fixes an issue with overlapping `icon` helper methods.