### PR TITLE
Add White Bitbucket Logo

### DIFF
--- a/assets/icons/logos/bitbucket-color.svg
+++ b/assets/icons/logos/bitbucket-color.svg
@@ -5,6 +5,6 @@
       <stop offset="1" stop-color="#2684ff" />
     </linearGradient>
   </defs>
-  <path class="icon-bitbucket" fill="#2684ff" d="M.52.81a.51.51,0,0,0-.52.5A.28.28,0,0,0,0,1.4L2.18,14.61a.69.69,0,0,0,.68.58H13.3a.51.51,0,0,0,.52-.43L16,1.4a.5.5,0,0,0-.42-.58H.52Zm9.16,9.54H6.35l-.9-4.71h5Z" />
-  <path class="icon-bitbucket-gradient" fill="url(#bitbucket-color-gradient)" d="M15.3,5.64H10.49l-.81,4.71H6.35L2.42,15a.66.66,0,0,0,.44.17H13.31a.51.51,0,0,0,.51-.43Z"/>
+  <path class="icon-bitbucket-color" fill="#2684ff" d="M.52.81a.51.51,0,0,0-.52.5A.28.28,0,0,0,0,1.4L2.18,14.61a.69.69,0,0,0,.68.58H13.3a.51.51,0,0,0,.52-.43L16,1.4a.5.5,0,0,0-.42-.58H.52Zm9.16,9.54H6.35l-.9-4.71h5Z" />
+  <path class="icon-bitbucket-color-gradient" fill="url(#bitbucket-color-gradient)" d="M15.3,5.64H10.49l-.81,4.71H6.35L2.42,15a.66.66,0,0,0,.44.17H13.31a.51.51,0,0,0,.51-.43Z"/>
 </svg>

--- a/assets/icons/logos/bitbucket-white.svg
+++ b/assets/icons/logos/bitbucket-white.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <defs>
+    <linearGradient id="bitbucket-white-gradient" x1="16.36" y1="6.99" x2="3.79" y2="16.81" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#fff" stop-opacity="0.3" />
+      <stop offset="0.6" stop-color="#fff" />
+    </linearGradient>
+  </defs>
+  <path class="icon-bitbucket-white" fill="#fff" d="M6.35,10.35l-.9-4.71h9.86L16,1.4a.51.51,0,0,0-.41-.58H.52a.51.51,0,0,0-.52.5H0V1.4L2.18,14.61a.7.7,0,0,0,.23.41Z" />
+  <path class="icon-bitbucket-white-gradient" fill="url(#bitbucket-white-gradient)" d="M9.68,10.35H6.35L2.18,14.61a.7.7,0,0,0,.23.41h0a.8.8,0,0,0,.27.15l.18,0H13.3a.51.51,0,0,0,.52-.43l1.49-9.12H10.45Z" />
+</svg>

--- a/lib/shipyard-framework/version.rb
+++ b/lib/shipyard-framework/version.rb
@@ -1,3 +1,3 @@
 module Shipyard
-  VERSION = '0.5.72'
+  VERSION = '0.5.73'
 end

--- a/styleguide/Gemfile.lock
+++ b/styleguide/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    shipyard-framework (0.5.72)
+    shipyard-framework (0.5.73)
       actionview (~> 5.0)
       sprockets-es6 (~> 0.9.2)
 

--- a/styleguide/_plugins/icon_item.rb
+++ b/styleguide/_plugins/icon_item.rb
@@ -7,15 +7,17 @@ module Jekyll
     def initialize(tag_name, args, options)
       super
       args = args.strip.split(',')
-      @name = args[0]
+      @name = eval(args[0])
+      @tooltip = args[0]
       @options = args[1] ? eval("{#{args[1]}}") : {}
+      @css = 'bg-gray' if @name == 'bitbucket-white'
     end
 
     def render(context)
       %(
-        <li class="col col-50 col-x1-20 margin-bottom-xs margin-bottom-x1-md margin-bottom-x2-lg" tooltip="#{@name}">
-          <div class="box box-md box-x1-xxl">
-            #{icon eval(@name), @options}
+        <li class="col col-50 col-x1-20 margin-bottom-xs margin-bottom-x1-md margin-bottom-x2-lg" tooltip="#{@tooltip}">
+          <div class="box box-md box-x1-xxl #{@css}">
+            #{icon @name, @options}
           </div>
         </li>
       )

--- a/styleguide/components/icons.md
+++ b/styleguide/components/icons.md
@@ -27,6 +27,7 @@ description: Shipyard comes with several default icons that you're welcome to us
 <p class="text-light margin-bottom-md" markdown="1">If you need to style several paths inside of the icon, it's important to make sure you use the *injected* version of the icon.</p>
 
 <ul class="icon-list col-container">
+  {% iconitem 'bitbucket-white', class: 'center icon-xl' %}
   {% iconitem 'bitbucket', class: 'center gray icon-xl' %}
   {% iconitem 'bitbucket-color', class: 'center icon-xl' %}
   {% iconitem :campfire_color, class: 'center icon-xl' %}


### PR DESCRIPTION
Added support for a white bitbucket logo as seen in the screenshot below:

<img width="852" alt="screenshot 2017-11-22 10 45 21" src="https://user-images.githubusercontent.com/211597/33120448-63fcbf6e-cf72-11e7-9e04-44e571300cb4.png">
