### PR TITLE
Disabled Clicks on Disabled Buttons

### DIFF
--- a/assets/stylesheets/shipyard/components/_buttons.sass
+++ b/assets/stylesheets/shipyard/components/_buttons.sass
@@ -160,6 +160,7 @@
 
   &-disabled
     cursor: not-allowed
+    pointer-events: none
     &, &:hover, &:focus
       +btn-color(lighten($gray-lighter, 1%), $text-color-lightest)
     &:active

--- a/lib/shipyard-framework/version.rb
+++ b/lib/shipyard-framework/version.rb
@@ -1,3 +1,3 @@
 module Shipyard
-  VERSION = '0.5.75'
+  VERSION = '0.5.76'
 end

--- a/styleguide/Gemfile.lock
+++ b/styleguide/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    shipyard-framework (0.5.75)
+    shipyard-framework (0.5.76)
       actionview (~> 5.0)
       sprockets-es6 (~> 0.9.2)
 


### PR DESCRIPTION
This PR helps disable clicks on buttons that are links since the `disabled` attribute doesn't work like it does on a `button` or `input` tag.