### PR TITLE
Don't lock an executor when waiting

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,48 +1,81 @@
 pipeline {
-  agent {
-    dockerfile {
-      label 'docker'
-      filename './Dockerfile'
-    }
-  }
+  agent none
   stages {
     stage('Test') {
       parallel {
         stage('Jekyll') {
+          agent {
+            dockerfile {
+              label 'docker'
+              filename './Dockerfile'
+            }
+          }          
           steps {
             sh './ci/jekyll'
           }
         }
-        stage('RSpec') {
+        stage('RSpec') {          
+          agent {
+            dockerfile {
+              label 'docker'
+              filename './Dockerfile'
+            }
+          }   
+          
           steps {
             sh 'rspec -fd'
           }
         }
-        stage('SASS') {
+        stage('SASS') {          
+          agent {
+            dockerfile {
+              label 'docker'
+              filename './Dockerfile'
+            }
+          }
+          
           steps {
             sh './ci/sass_lint'
           }
         }
       }
     }
+    
     stage('Review') {
       when {
         not { branch 'master' }
       }
       steps {
-        input 'Ready to review the styleguide?'
+        input 'Ready to review the styleguide?'       
+      }
+    }
+    
+    stage('Percy') {
+      agent {
+        dockerfile {
+          label 'docker'
+          filename './Dockerfile'
+        }
+      }      
+      when {
+        not { branch 'master' }
+      }
+      steps {
         sh './ci/percy'
       }
     }
+    
     stage('Deploy') {
       when { branch 'master' }
       parallel {
         stage('RubyGems') {
+          agent any
           steps {
             echo 'This step only runs in Travis CI builds at the moment: https://travis-ci.org/codeship/shipyard'
           }
         }
         stage('GitHub Pages') {
+          agent any
           steps {
             echo 'This step only runs in Codeship builds at the moment: https://app.codeship.com/projects/246808'
           }


### PR DESCRIPTION
One way of doing it - unfortunately parallel and agent isn't just "one machine" like codeship, but each one could potentially be a different machine (distributed). No exact equivalent for codeship parallel guaranteed to be on one machine.