### PR TITLE
Improved Skipped Status Colors

### DIFF
--- a/assets/stylesheets/shipyard/components/_statuses.sass
+++ b/assets/stylesheets/shipyard/components/_statuses.sass
@@ -7,8 +7,8 @@
   top: -1px
   position: relative
   display: inline-block
-  color: $text-color-lightest
-  border: 2px solid $border-color-light
+  color: $gray
+  border: 2px solid $gray
   border-radius: 50%
   vertical-align: middle
   background-clip: border-box
@@ -47,6 +47,7 @@
 
   &-running
     color: $teal
+    border-color: $border-color-light
     &-bg
       background-color: $teal
     &.status-xs,
@@ -216,7 +217,7 @@
 
 +component('text')
   &-skipped
-    color: $text-color-lightest
+    color: $gray
   &-waiting
     color: $blue
   &-running

--- a/assets/stylesheets/shipyard/variables/_colors.scss
+++ b/assets/stylesheets/shipyard/variables/_colors.scss
@@ -1,5 +1,13 @@
 $shipyard-colors: (
+  // Shipyard: Black
   'black': #000,
+  'black-90': rgba(#000, .9),
+  'black-80': rgba(#000, .8),
+  'black-70': rgba(#000, .7),
+  'black-60': rgba(#000, .6),
+  'black-50': rgba(#000, .5),
+  'black-40': rgba(#000, .4),
+  'black-30': rgba(#000, .3),
 
   // Shipyard: White
   'white': #fff,
@@ -9,6 +17,7 @@ $shipyard-colors: (
   'white-60': rgba(#fff, .6),
   'white-50': rgba(#fff, .5),
   'white-40': rgba(#fff, .4),
+  'white-30': rgba(#fff, .3),
 
   // Shipyard: Gray
   'gray': #788594,

--- a/lib/shipyard-framework/version.rb
+++ b/lib/shipyard-framework/version.rb
@@ -1,3 +1,3 @@
 module Shipyard
-  VERSION = '0.8.0'
+  VERSION = '0.8.1'
 end

--- a/styleguide/Gemfile.lock
+++ b/styleguide/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    shipyard-framework (0.8.0)
+    shipyard-framework (0.8.1)
       actionview (~> 5.0)
       sprockets-es6 (~> 0.9.2)
 


### PR DESCRIPTION
This PR makes the `skipped` status a little more readable as well in more situations (light and dark backgrounds).

<img width="636" alt="screenshot 2018-04-16 16 18 58" src="https://user-images.githubusercontent.com/211597/38814510-f46ee2ac-4191-11e8-8b97-7aa43c93f1c2.png">
<img width="772" alt="screenshot 2018-04-16 16 19 10" src="https://user-images.githubusercontent.com/211597/38814511-f498680c-4191-11e8-856f-95b55b9a84a6.png">
<img width="177" alt="screenshot 2018-04-16 16 19 16" src="https://user-images.githubusercontent.com/211597/38814512-f4bb8b66-4191-11e8-99a6-bebb06315c99.png">
<img width="236" alt="screenshot 2018-04-16 16 19 23" src="https://user-images.githubusercontent.com/211597/38814514-f4db27e6-4191-11e8-8b3b-f6c64b4e81c0.png">
